### PR TITLE
Bugfix 6008/fix spacing problem in T4T

### DIFF
--- a/__tests__/__snapshots__/Container.test.js.snap
+++ b/__tests__/__snapshots__/Container.test.js.snap
@@ -4867,7 +4867,6 @@ exports[`Container Tests Test Container 1`] = `
                     >
                       .
 
-
                     </span>
                   </div>
                 </div>
@@ -5233,8 +5232,7 @@ exports[`Container Tests Test Container 1`] = `
                     <span
                       style="background-color:var(--highlight-color)"
                     >
-                      . 
-
+                      .  
                     </span>
                   </div>
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -827,9 +827,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.1.tgz",
-      "integrity": "sha512-nlxajcFXWFyrFOyzOkphfby2izqoB9B4a3+rMqG4dBKMaHZUUS3BkgFBIAbNK6s+VOx0vaGJVgaQL0+3oWnxDQ==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.2.tgz",
+      "integrity": "sha512-GfVnHchOBvIMsweQ13l4jd9lT4brkevnavnVOej5g2y7PpTRY+R4pcQlCjWMZoUla5rMLFzaS/Ll2s59cB1TqQ==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
@@ -8783,9 +8783,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "0.15.4-beta.1",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.4-beta.1.tgz",
-      "integrity": "sha512-Ejb+0VPH649kt1ms+J1aR5DxrmEqu6LAC2j+09UXQuq1I+D+4eooneAh6omFaB0MlNF2ojdUY/PL7wVK4lT1xA==",
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.4.tgz",
+      "integrity": "sha512-cb8VIo/V3PKeXThj2keq1WoluZMM72YDL70ht7hBPcsJycT2XccME3tHfzGXzaDjZpycetl6VrH04sgAn42uUQ==",
       "requires": {
         "@material-ui/core": "^3.8.3",
         "@material-ui/icons": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -827,9 +827,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.6.3.tgz",
-      "integrity": "sha512-nuA2o+rgX2+PrNTZ063ehncVcg7sn+tU71BB81SaWRVUbGwCOlb0+yQA1e0QqmzOfRSYOxfvf8cosYqFbJEiwQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.1.tgz",
+      "integrity": "sha512-nlxajcFXWFyrFOyzOkphfby2izqoB9B4a3+rMqG4dBKMaHZUUS3BkgFBIAbNK6s+VOx0vaGJVgaQL0+3oWnxDQ==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
@@ -1270,9 +1270,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.9.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.9.tgz",
-      "integrity": "sha512-L+AudFJkDukk+ukInYvpoAPyJK5q1GanFOINOJnM0w6tUgITuWvJ4jyoBPFL7z4/L8hGLd+K/6xR5uUjXu0vVg==",
+      "version": "16.9.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.11.tgz",
+      "integrity": "sha512-UBT4GZ3PokTXSWmdgC/GeCGEJXE5ofWyibCcecRLUVN2ZBpXQGVgQGtG2foS7CrTKFKlQVVswLvf7Js6XA/CVQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -4169,8 +4169,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4188,13 +4187,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4207,18 +4204,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4321,8 +4315,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4332,7 +4325,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4345,20 +4337,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4375,7 +4364,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4448,8 +4436,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4459,7 +4446,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4535,8 +4521,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4566,7 +4551,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4584,7 +4568,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4623,13 +4606,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -8802,9 +8783,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.2.tgz",
-      "integrity": "sha512-vLST6iAw5sNoKIyDShSlqxHL8Q0buX9Bjj8i+lfG1nrwGSKFsUOVWW/l8Z0DTLcOGDLWTawgQizVs/T4wNwosg==",
+      "version": "0.15.4-beta.1",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.4-beta.1.tgz",
+      "integrity": "sha512-Ejb+0VPH649kt1ms+J1aR5DxrmEqu6LAC2j+09UXQuq1I+D+4eooneAh6omFaB0MlNF2ojdUY/PL7wVK4lT1xA==",
       "requires": {
         "@material-ui/core": "^3.8.3",
         "@material-ui/icons": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.1",
+  "version": "1.0.3-beta.1",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
     "selections": "0.1.7",
-    "tc-ui-toolkit": "0.15.2",
+    "tc-ui-toolkit": "0.15.4-beta.1",
     "usfm-js": "2.0.1"
   }
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix problem that spaces in html are not always shown by replacing leading and trailing spaces with no-break-space.
- fix problem with displaying in HTML: USFM that has an end marker.

#### Please include detailed Test instructions for your pull request:
- this was already reviewed build in https://github.com/unfoldingWord/tc-ui-toolkit/pull/238, but if you want to review again:
  - use test build attached below.
  - update english resources to get the t4t bible.
  - open a John project and launch WA tool
  - navigate to John 6:4
  - add the t4t (translation for translators) to the scripture pane and make sure the issue in https://github.com/unfoldingword/translationcore/issues/6008 is fixed.
