### PR TITLE
Bugfix 6008/Fix whitespace rendering

### DIFF
--- a/__tests__/__snapshots__/Container.test.js.snap
+++ b/__tests__/__snapshots__/Container.test.js.snap
@@ -4868,6 +4868,11 @@ exports[`Container Tests Test Container 1`] = `
                       .
 
                     </span>
+                    <span
+                      style="background-color:transparent"
+                    >
+                       
+                    </span>
                   </div>
                 </div>
               </div>
@@ -5232,7 +5237,12 @@ exports[`Container Tests Test Container 1`] = `
                     <span
                       style="background-color:var(--highlight-color)"
                     >
-                      .  
+                      . 
+                    </span>
+                    <span
+                      style="background-color:transparent"
+                    >
+                       
                     </span>
                   </div>
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "1.0.4",
+  "version": "1.0.5-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8783,9 +8783,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.4.tgz",
-      "integrity": "sha512-cb8VIo/V3PKeXThj2keq1WoluZMM72YDL70ht7hBPcsJycT2XccME3tHfzGXzaDjZpycetl6VrH04sgAn42uUQ==",
+      "version": "0.15.5-beta",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.5-beta.tgz",
+      "integrity": "sha512-eYrTlehlElhxktVovRNXAiEwQUXyOciGqN2JiqbqTlUcFqeJq059CcjJYRV6NZmPOqUMdgnPDBF70M8OvY+XkQ==",
       "requires": {
         "@material-ui/core": "^3.8.3",
         "@material-ui/icons": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "1.0.5-beta",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8783,9 +8783,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "0.15.5-beta",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.5-beta.tgz",
-      "integrity": "sha512-eYrTlehlElhxktVovRNXAiEwQUXyOciGqN2JiqbqTlUcFqeJq059CcjJYRV6NZmPOqUMdgnPDBF70M8OvY+XkQ==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.5.tgz",
+      "integrity": "sha512-tb60vWF+EgxzkHKXYv0vNwW/JIO3TzVHppUUJ5kpo7hTQzpy51DflyC1xzovUdIjgR/mLpF6PgFp4uHSzIW1bw==",
       "requires": {
         "@material-ui/core": "^3.8.3",
         "@material-ui/icons": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.5-beta",
+  "version": "1.0.5",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",
@@ -70,7 +70,7 @@
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
     "selections": "0.1.7",
-    "tc-ui-toolkit": "0.15.5-beta",
+    "tc-ui-toolkit": "0.15.5",
     "usfm-js": "2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.4",
+  "version": "1.0.5-beta",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",
@@ -70,7 +70,7 @@
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
     "selections": "0.1.7",
-    "tc-ui-toolkit": "0.15.4",
+    "tc-ui-toolkit": "0.15.5-beta",
     "usfm-js": "2.0.1"
   }
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- removed non-break space which caused rendering problem.  Now using our standard space span.

#### Please include detailed Test instructions for your pull request:
- already tested with https://github.com/unfoldingWord/tc-ui-toolkit/pull/241, but if you want to test again you can use test build attached below.
  - update english resources to get the t4t bible.
  - open a John project and launch WA tool
  - add the t4t (translation for translators) to the scripture pane
  - navigate to John 6:21  and make sure the original issue in unfoldingWord/translationCore#6008 is fixed in t4t.
  - navigate to John 18:38 and make sure `"How` is rendered correctly without a space after `"`
  - navigate to John 19:14 and make sure it is rendered like screenshot in x2.1.0 (605b3a6) 

