### PR TITLE
Bugfix 5705/On the dialog to add resources to the scripture pane, localize close and load buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "1.0.6",
+  "version": "1.0.7-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1141,9 +1141,9 @@
       },
       "dependencies": {
         "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+          "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
           "requires": {
             "react-is": "^16.7.0"
           }
@@ -8783,9 +8783,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.5.tgz",
-      "integrity": "sha512-tb60vWF+EgxzkHKXYv0vNwW/JIO3TzVHppUUJ5kpo7hTQzpy51DflyC1xzovUdIjgR/mLpF6PgFp4uHSzIW1bw==",
+      "version": "0.15.6-beta.3",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.6-beta.3.tgz",
+      "integrity": "sha512-HDvFj38uhkkpjGssWF1UxoimjXC+xyods0UVMtHfLY4RzST7A2v9zBbWwU31qjWrNUNXS6QOXVQ3cuBpANfkJQ==",
       "requires": {
         "@material-ui/core": "^3.8.3",
         "@material-ui/icons": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "1.0.7-beta",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8783,9 +8783,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "0.15.6-beta.3",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.6-beta.3.tgz",
-      "integrity": "sha512-HDvFj38uhkkpjGssWF1UxoimjXC+xyods0UVMtHfLY4RzST7A2v9zBbWwU31qjWrNUNXS6QOXVQ3cuBpANfkJQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-0.15.6.tgz",
+      "integrity": "sha512-dLhc3bbeBy70m556U0tdw41SPsIBImn+K6Pd5o5NJBjghFe84mM1wrG7j+cZgq+KC3Mm7C3JB2HY+gQoCKO/eQ==",
       "requires": {
         "@material-ui/core": "^3.8.3",
         "@material-ui/icons": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.6",
+  "version": "1.0.7-beta",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",
@@ -70,7 +70,7 @@
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
     "selections": "0.1.7",
-    "tc-ui-toolkit": "0.15.5",
+    "tc-ui-toolkit": "0.15.6-beta.3",
     "usfm-js": "2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.7-beta",
+  "version": "1.0.7",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",
@@ -70,7 +70,7 @@
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
     "selections": "0.1.7",
-    "tc-ui-toolkit": "0.15.6-beta.3",
+    "tc-ui-toolkit": "0.15.6",
     "usfm-js": "2.0.1"
   }
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- update tc-ui-toolkit

#### Please include detailed Test instructions for your pull request:
- use test build attached below.
- for each tool: wa, tw, tn:
  - launch tool
  - make sure locale is set to English
  - on Scripture pane click on add resources icon.
  - from drop down, select a resource
  - on dialog, should see valid text on Close and Load buttons
  - click Close button
  - set locale to language other than English
  - on Scripture pane click on add resources icon.
  - from drop down, select a resource
  - on dialog, should see valid text on Close button (left).  Load button should say "missing translation key..." since we do not yet have translation for the button text.
  - click Close button (left)
  - change locale to English
