### PR TITLE
QA Fail 6586/Fix crash when resources are updated on tN project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.11-beta",
+  "version": "1.0.11-beta.2",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.11-beta.8",
+  "version": "1.0.11",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.11-beta.2",
+  "version": "1.0.11-beta.3",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.10",
+  "version": "1.0.11-beta",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.11-beta.4",
+  "version": "1.0.11-beta.5",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.11-beta.3",
+  "version": "1.0.11-beta.4",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "1.0.11-beta.5",
+  "version": "1.0.11-beta.8",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/Api.js
+++ b/src/Api.js
@@ -158,6 +158,7 @@ export default class Api extends ToolApi {
                 checkingOccurrence.contextId.quote,
                 checkingOccurrence.contextId.occurrence
               );
+              console.log(`Api._validateVerse() - invalidating: ${JSON.stringify(selectionsObject)}`);
               //If selections are changed, they need to be cleared
               selectionsChanged = true;
               const invalidatedCheckPath = path.join(projectSaveLocation, '.apps', 'translationCore', 'checkData', 'invalidated', bookId, chapter.toString(), verse.toString());
@@ -216,7 +217,7 @@ export default class Api extends ToolApi {
             completedChecks += (check.selections || check.nothingToSelect) ? 1 : 0;
           }
         } else {
-          console.warn(`Invalid group data found for "${group}"`);
+          console.warn(`Api.getProgress() - Invalid group data found for "${group}"`);
         }
       }
     }
@@ -331,7 +332,7 @@ export default class Api extends ToolApi {
             return recordData;
           }
         } catch (e) {
-          console.warn(`Failed to load check record from ${recordPath}, recordData: ${jsonData}`, e);
+          console.warn(`Api.loadCheckData() - Failed to load check record from ${recordPath}, recordData: ${jsonData}`, e);
         }
       }
     }
@@ -362,7 +363,7 @@ export default class Api extends ToolApi {
           }
         }
       } else {
-        console.warn(`Invalid group data found for "${group}"`);
+        console.warn(`Api.getInvalidChecks() - Invalid group data found for "${group}"`);
       }
     }
     return invalidChecks;

--- a/src/Api.js
+++ b/src/Api.js
@@ -312,14 +312,16 @@ export default class Api extends ToolApi {
       const files = project.readDataDirSync(loadPath).filter(file => path.extname(file) === '.json');
       let sortedRecords = files.sort().reverse();
       const isQuoteArray = Array.isArray(quote);
+      let recordData;
 
       // load check data
       for (let i = 0, len = sortedRecords.length; i < len; i++) {
         const record = sortedRecords[i];
         const recordPath = path.join(loadPath, record);
+        recordData = null;
 
         try {
-          const recordData = JSON.parse(project.readDataFileSync(recordPath));
+          recordData = JSON.parse(project.readDataFileSync(recordPath));
 
           // return first match
           if (recordData.contextId.groupId === groupId &&
@@ -328,7 +330,7 @@ export default class Api extends ToolApi {
             return recordData;
           }
         } catch (e) {
-          console.warn(`Failed to load check record from ${recordPath}`, e);
+          console.warn(`Failed to load check record from ${recordPath}, recordData: ${recordData}`, e);
         }
       }
     }

--- a/src/Api.js
+++ b/src/Api.js
@@ -312,16 +312,17 @@ export default class Api extends ToolApi {
       const files = project.readDataDirSync(loadPath).filter(file => path.extname(file) === '.json');
       let sortedRecords = files.sort().reverse();
       const isQuoteArray = Array.isArray(quote);
-      let recordData;
+      let jsonData;
 
       // load check data
       for (let i = 0, len = sortedRecords.length; i < len; i++) {
         const record = sortedRecords[i];
         const recordPath = path.join(loadPath, record);
-        recordData = null;
+        jsonData = null;
 
         try {
-          recordData = JSON.parse(project.readDataFileSync(recordPath));
+          jsonData = project.readDataFileSync(recordPath);
+          const recordData = JSON.parse(jsonData);
 
           // return first match
           if (recordData.contextId.groupId === groupId &&
@@ -330,7 +331,7 @@ export default class Api extends ToolApi {
             return recordData;
           }
         } catch (e) {
-          console.warn(`Failed to load check record from ${recordPath}, recordData: ${recordData}`, e);
+          console.warn(`Failed to load check record from ${recordPath}, recordData: ${jsonData}`, e);
         }
       }
     }

--- a/src/Api.js
+++ b/src/Api.js
@@ -158,25 +158,29 @@ export default class Api extends ToolApi {
                 checkingOccurrence.contextId.quote,
                 checkingOccurrence.contextId.occurrence
               );
-              console.log(`Api._validateVerse() - invalidating: ${JSON.stringify(selectionsObject)}`);
-              //If selections are changed, they need to be cleared
-              selectionsChanged = true;
-              const invalidatedCheckPath = path.join(projectSaveLocation, '.apps', 'translationCore', 'checkData', 'invalidated', bookId, chapter.toString(), verse.toString());
-              const invalidatedPayload = {
-                ...selectionsObject,
-                invalidated: true,
-                selections: [],
-                userName,
-              };
-              this.writeCheckData(invalidatedPayload, invalidatedCheckPath, modifiedTimestamp);
 
-              const selectionsCheckPath = path.join(projectSaveLocation, '.apps', 'translationCore', 'checkData', 'selections', bookId, chapter.toString(), verse.toString());
-              const selectionsPayload = {
-                ...selectionsObject,
-                selections: [],
-                userName,
-              };
-              this.writeCheckData(selectionsPayload, selectionsCheckPath, modifiedTimestamp);
+              if (selectionsObject.contextId) {
+                //If selections are changed, they need to be cleared
+                selectionsChanged = true;
+                const invalidatedCheckPath = path.join(projectSaveLocation, '.apps', 'translationCore', 'checkData', 'invalidated', bookId, chapter.toString(), verse.toString());
+                const invalidatedPayload = {
+                  ...selectionsObject,
+                  invalidated: true,
+                  selections: [],
+                  userName,
+                };
+                this.writeCheckData(invalidatedPayload, invalidatedCheckPath, modifiedTimestamp);
+
+                const selectionsCheckPath = path.join(projectSaveLocation, '.apps', 'translationCore', 'checkData', 'selections', bookId, chapter.toString(), verse.toString());
+                const selectionsPayload = {
+                  ...selectionsObject,
+                  selections: [],
+                  userName,
+                };
+                this.writeCheckData(selectionsPayload, selectionsCheckPath, modifiedTimestamp);
+              } else {
+                console.warn(`Api._validateVerse() - could not find selections for verse ${chapter}:${verse}, checkingOccurrence: ${JSON.stringify(checkingOccurrence)}`);
+              }
             }
           }
         }

--- a/src/helpers/validationHelpers.js
+++ b/src/helpers/validationHelpers.js
@@ -53,7 +53,12 @@ export function getSelectionsFromChapterAndVerseCombo(bookId, chapter, verse, pr
 
     if (quote) {
       for (let filename of sorted) {
-        const currentSelectionsObject = fs.readJsonSync(path.join(selectionsPath, filename));
+        const pathToOBject = path.join(selectionsPath, filename);
+        const currentSelectionsObject = fs.readJsonSync(pathToOBject);
+
+        if (!currentSelectionsObject.contextId) {
+          console.error(`getSelectionsFromChapterAndVerseCombo() - missing contextId ${pathToOBject}`);
+        }
 
         if ((currentSelectionsObject.contextId.occurrence === occurrence) &&
           isEqual(currentSelectionsObject.contextId.quote, quote)) { // supports quote arrays or strings

--- a/src/helpers/validationHelpers.js
+++ b/src/helpers/validationHelpers.js
@@ -57,7 +57,7 @@ export function getSelectionsFromChapterAndVerseCombo(bookId, chapter, verse, pr
         const currentSelectionsObject = fs.readJsonSync(pathToSelections);
 
         if (!currentSelectionsObject.contextId) {
-          console.error(`getSelectionsFromChapterAndVerseCombo() - missing contextId ${pathToSelections}`);
+          console.warn(`getSelectionsFromChapterAndVerseCombo() - missing contextId ${pathToSelections}`);
         } else {
           if ((currentSelectionsObject.contextId.occurrence === occurrence) &&
             isEqual(currentSelectionsObject.contextId.quote, quote)) { // supports quote arrays or strings

--- a/src/helpers/validationHelpers.js
+++ b/src/helpers/validationHelpers.js
@@ -53,16 +53,16 @@ export function getSelectionsFromChapterAndVerseCombo(bookId, chapter, verse, pr
 
     if (quote) {
       for (let filename of sorted) {
-        const pathToOBject = path.join(selectionsPath, filename);
-        const currentSelectionsObject = fs.readJsonSync(pathToOBject);
+        const pathToSelections = path.join(selectionsPath, filename);
+        const currentSelectionsObject = fs.readJsonSync(pathToSelections);
 
         if (!currentSelectionsObject.contextId) {
-          console.error(`getSelectionsFromChapterAndVerseCombo() - missing contextId ${pathToOBject}`);
-        }
-
-        if ((currentSelectionsObject.contextId.occurrence === occurrence) &&
-          isEqual(currentSelectionsObject.contextId.quote, quote)) { // supports quote arrays or strings
-          return currentSelectionsObject;
+          console.error(`getSelectionsFromChapterAndVerseCombo() - missing contextId ${pathToSelections}`);
+        } else {
+          if ((currentSelectionsObject.contextId.occurrence === occurrence) &&
+            isEqual(currentSelectionsObject.contextId.quote, quote)) { // supports quote arrays or strings
+            return currentSelectionsObject;
+          }
         }
       }
     }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- added error recovery/logging for when existing selections cannot be found in new resources (e.g. versification changes)
- added error recovery/logging when contextId is missing when loading current selections.
- improved logging to give more helpful info when check data is not found 

#### Please include detailed Test instructions for your pull request:
- use attached build for testing.
- import project in https://github.com/unfoldingWord/translationCore/issues/6586 from D43.  It should import and open without crashing.  There will be lots of invalidations.
- Note that this project has broken selections due to changes in versification in uhb in Ruth.  Also some groupIds in the tsv have been renamed/moved. So had to add some sanity checking to the module so it does not crash.