### PR TITLE
Bugfix 6676/Add graceful handling if check is not found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "2.0.0",
+  "version": "2.0.1-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "2.0.1-beta.2",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "2.0.0",
+  "version": "2.0.1-beta.2",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "2.0.1-beta.2",
+  "version": "2.0.1",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/helpers/ProjectAPI.js
+++ b/src/helpers/ProjectAPI.js
@@ -119,8 +119,8 @@ export default class ProjectAPI {
                 verse.toString()
               );
 
-              const { selections } = loadCheckData(loadPath, groupDataItem.contextId);
-              groupDataItem.selections = selections || false;
+              const checkData = loadCheckData(loadPath, groupDataItem.contextId);
+              groupDataItem.selections = (checkData && checkData.selections) || false;
               return groupDataItem;
             }
             return groupDataItem;


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix getGroupsData() - add graceful handling if check is not found

#### Please include detailed Test instructions for your pull request:
- can use build attached to https://github.com/unfoldingWord/translationCore/pull/6680
- when opening project attached to issue https://github.com/unfoldingword/translationcore/issues/6676 should see `pure, purify...` topic in tW

