### PR TITLE
Bugfix 6675/Fix alignment validation on verse edit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "2.0.2",
+  "version": "2.0.3-beta",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "2.0.3-beta",
+  "version": "2.0.3",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/Api.js
+++ b/src/Api.js
@@ -96,6 +96,7 @@ export default class Api extends ToolApi {
     const { tc: { tools } } = this.props;
     const wA_api = tools && tools[WORD_ALIGNMENT];
 
+    // TODO: this is a temporary fix - as we finish tool reducer updates we should call API in tCore since tools should not have knowledge of one another
     if (wA_api) {
       return wA_api.trigger('validateVerse', chapter, verse, silent);
     }

--- a/src/Api.js
+++ b/src/Api.js
@@ -13,6 +13,7 @@ import { getGroupDataForVerse } from './helpers/groupDataHelpers';
 import { getSelectionsFromChapterAndVerseCombo, generateTimestamp } from './helpers/validationHelpers';
 import { getQuoteAsString } from './helpers/checkAreaHelpers';
 import { sameContext } from './helpers/contextIdHelpers';
+import { WORD_ALIGNMENT } from './common/constants';
 
 export default class Api extends ToolApi {
   constructor() {
@@ -21,6 +22,7 @@ export default class Api extends ToolApi {
     this.getInvalidChecks = this.getInvalidChecks.bind(this);
     this.getProgress = this.getProgress.bind(this);
     this.validateVerse = this.validateVerse.bind(this);
+    this.validateVerseAlignments = this.validateVerseAlignments.bind(this);
     this._loadBookSelections = this._loadBookSelections.bind(this);
     this._loadVerseSelections = this._loadVerseSelections.bind(this);
     this._loadCheckData = this._loadCheckData.bind(this);
@@ -81,6 +83,23 @@ export default class Api extends ToolApi {
         }
       }
     }
+  }
+
+  /**
+   * checks the alignments for changes
+   * @param {String} chapter
+   * @param {String} verse
+   * @param {boolean} silent - if true then don't show alerts
+   * @returns {boolean} true if valid
+   */
+  validateVerseAlignments(chapter, verse, silent=false) {
+    const { tc: { tools } } = this.props;
+    const wA_api = tools && tools[WORD_ALIGNMENT];
+
+    if (wA_api) {
+      return wA_api.trigger('validateVerse', chapter, verse, silent);
+    }
+    return false;
   }
 
   /**

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -118,9 +118,7 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
  * @param {function} updateTargetVerse -
  * @param {object} toolApi -
  */
-export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWithVerseEdit, currentCheckContextId, showSelectionInvalidated, batchGroupData = null, currentToolName, translate, showAlert, closeAlert, projectSaveLocation, showIgnorableAlert, updateTargetVerse, toolApi) => async (dispatch, getState) => {
-  const state = getState();
-  const groupsData = getGroupsData(state);
+export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWithVerseEdit, currentCheckContextId, showSelectionInvalidated, batchGroupData = null, currentToolName, translate, showAlert, closeAlert, projectSaveLocation, showIgnorableAlert, updateTargetVerse, toolApi) => async (dispatch) => {
   const actionsBatch = Array.isArray(batchGroupData) ? batchGroupData : []; // if batch array passed in then use it, otherwise create new array
   showAlert(translate('invalidation_checking'), true);
   await delay(300);
@@ -128,8 +126,7 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
   const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
   updateTargetVerse(chapterWithVerseEdit, verseWithVerseEdit, verseEdit.verseAfter);
 
-  let showAlignmentsInvalidated = false;
-  showAlignmentsInvalidated = !toolApi.validateVerse(chapterWithVerseEdit, verseWithVerseEdit, true, groupsData);
+  const showAlignmentsInvalidated = !toolApi.validateVerseAlignments(chapterWithVerseEdit, verseWithVerseEdit, true);
   closeAlert();
 
   if (showSelectionInvalidated || showAlignmentsInvalidated) {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix alignment validation on verse edits in tW and tN tools

#### Please include detailed Test instructions for your pull request:
- use build 2.2.0 (5041de3)  in https://github.com/unfoldingWord/translationCore/pull/6697
- edits in tN and tW should result in verse edit marker in WA tool.
