### PR TITLE
Bugfix 6686/Fix invalid check detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "2.0.3",
+  "version": "2.0.4-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "2.0.3",
+  "version": "2.0.4-beta",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "2.0.4-beta",
+  "version": "2.0.4",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/helpers/gatewayLanguageHelpers.js
+++ b/src/helpers/gatewayLanguageHelpers.js
@@ -38,7 +38,6 @@ export function getAlignedGLTextHelper(contextId, glBibles) {
         return alignedText;
       }
     }
-    return contextId.quote;
   }
 
   return null;
@@ -52,7 +51,7 @@ export function getAlignedGLTextHelper(contextId, glBibles) {
 export function bibleIdSort(a, b) {
   const biblePrecedence = ['udb', 'ust', 'ulb', 'ult', 'irv']; // these should come first in this order if more than one aligned Bible, from least to greatest
 
-  if (biblePrecedence.indexOf(a) == biblePrecedence.indexOf(b)) {
+  if (biblePrecedence.indexOf(a) === biblePrecedence.indexOf(b)) {
     return (a < b ? -1 : a > b ? 1 : 0);
   } else {
     return biblePrecedence.indexOf(b) - biblePrecedence.indexOf(a);


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix problem in getAlignedGLTextHelper() that was returning original language quote for check when match was not found in GL bibles.  The result was that there was no warning to user about invalid checks, and the the verse check instructions would show Objects.

#### Please include detailed Test instructions for your pull request:
- test with project in issue https://github.com/unfoldingword/translationcore/issues/6686.  
- use build 2.2.0-f33ef24 in checks tab on https://github.com/unfoldingWord/translationCore/pull/6700
- make sure you have latest greek and hindi resources downloaded.
- for tN set GL to hi.
- open the above project in tN, the Group is already selected.  Just need select verse 1:22.
- should get warning that check is invalid.

