### PR TITLE
Bugfix 6678/Save verse edits for all checks in group data index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.2",
+  "version": "3.0.2-beta.3",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.2-beta",
+  "version": "3.0.2-beta.2",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.2-beta.2",
+  "version": "3.0.2",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.0",
+  "version": "3.0.2-beta",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.2-beta.3",
+  "version": "3.0.2",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/helpers/checkDataHelpers.js
+++ b/src/helpers/checkDataHelpers.js
@@ -10,6 +10,19 @@ import {
 } from '../state/actions/actionTypes';
 
 /**x
+ * @description loads checkdata from project for specific key.
+ * @param {string} projectSaveLocation - path to project
+ * @param {object} contextId - groupData unique context Id.
+ * @param {string} key - to fetch (e.g. 'selections')
+ * @return {object} returns the object loaded from the file system.
+ */
+export function loadCheckDataForKey(projectSaveLocation, contextId, key) {
+  const loadPath = generateLoadPath(projectSaveLocation, contextId, key);
+  const checkData = loadCheckData(loadPath, contextId);
+  return checkData;
+}
+
+/**x
  * @description loads checkdata based on given contextId.
  * @param {String} loadPath - load path.
  * @param {object} contextId - groupData unique context Id.
@@ -90,8 +103,7 @@ export function generateLoadPath(projectSaveLocation, contextId, checkDataName) 
  * @return {Object} Dispatches an action that loads the commentsReducer with data.
  */
 export function loadComments(projectSaveLocation, contextId) {
-  const loadPath = generateLoadPath(projectSaveLocation, contextId, 'comments');
-  const commentsObject = loadCheckData(loadPath, contextId);
+  const commentsObject = loadCheckDataForKey(projectSaveLocation, contextId, 'comments');
 
   if (commentsObject) {
     return {
@@ -119,8 +131,7 @@ export function loadComments(projectSaveLocation, contextId) {
  * @param {*} gatewayLanguageQuote - gateway language quote.
  */
 export function loadInvalidated(projectSaveLocation, contextId, gatewayLanguageCode, gatewayLanguageQuote) {
-  const loadPath = generateLoadPath(projectSaveLocation, contextId, 'invalidated');
-  const invalidatedObject = loadCheckData(loadPath, contextId);
+  const invalidatedObject = loadCheckDataForKey(projectSaveLocation, contextId, 'invalidated');
 
   if (invalidatedObject) {
     return {
@@ -152,8 +163,7 @@ export function loadInvalidated(projectSaveLocation, contextId, gatewayLanguageC
  * @param {*} gatewayLanguageQuote - gateway language quote.
  */
 export function loadBookmarks(projectSaveLocation, contextId, gatewayLanguageCode, gatewayLanguageQuote) {
-  const loadPath = generateLoadPath(projectSaveLocation, contextId, 'reminders');
-  const remindersObject = loadCheckData(loadPath, contextId);
+  const remindersObject = loadCheckDataForKey(projectSaveLocation, contextId, 'reminders');
 
   if (remindersObject) {
     return {
@@ -179,12 +189,12 @@ export function loadBookmarks(projectSaveLocation, contextId, gatewayLanguageCod
 
 /**
  * Loads the latest selections file from the file system for the specific contextID.
- * @param {Object} state - store state object.
+ * @param {*} projectSaveLocation - project path.
+ * @param {*} contextId - context id.
  * @return {Object} Dispatches an action that loads the selectionsReducer with data.
  */
 export function loadSelections(projectSaveLocation, contextId) {
-  const loadPath = generateLoadPath(projectSaveLocation, contextId, 'selections');
-  const selectionsObject = loadCheckData(loadPath, contextId);
+  const selectionsObject = loadCheckDataForKey(projectSaveLocation, contextId, 'selections');
 
   if (selectionsObject) {
     let {

--- a/src/helpers/groupDataHelpers.js
+++ b/src/helpers/groupDataHelpers.js
@@ -1,4 +1,6 @@
 import isEqual from 'deep-equal';
+import path from 'path-extra';
+import fs from 'fs-extra';
 import { saveGroupsData } from '../localStorage/saveMethods';
 import ProjectAPI from './ProjectAPI';
 
@@ -48,6 +50,31 @@ export const getGroupDataForVerse = (groupsData, contextId) => {
 export function loadProjectGroupData(toolName, projectDir) {
   const project = new ProjectAPI(projectDir);
   return project.getGroupsData(toolName);
+}
+
+/**
+ * gets path to a tool's group data from the project.
+ * @param {string} toolName - the name of the tool who's helps will be loaded
+ * @param {string} projectDir - the absolute path to the project
+ * @param {string} groupID - group identifier
+ * @returns {string} path to a tool's group data
+ */
+export function getGroupDataIndexPath(toolName, projectDir, groupID) {
+  const project = new ProjectAPI(projectDir);
+  return path.join(project.getCategoriesDir(toolName), groupID + '.json');
+}
+
+/**
+ * gets path to a tool's group data from the project.
+ * @param {string} toolName - the name of the tool who's helps will be loaded
+ * @param {string} projectDir - the absolute path to the project
+ * @param {string} groupID - group identifier
+ * @param {object} groupData - data to save
+ * @returns {string} path to a tool's group data
+ */
+export function saveGroupData(toolName, projectDir, groupID, groupData) {
+  const dataPath = getGroupDataIndexPath(toolName, projectDir, groupID);
+  return fs.outputJson(dataPath, groupData);
 }
 
 /**

--- a/src/helpers/groupDataHelpers.js
+++ b/src/helpers/groupDataHelpers.js
@@ -74,7 +74,7 @@ export function getGroupDataIndexPath(toolName, projectDir, groupID) {
  */
 export function saveGroupData(toolName, projectDir, groupID, groupData) {
   const dataPath = getGroupDataIndexPath(toolName, projectDir, groupID);
-  return fs.outputJson(dataPath, groupData, { spaces: 2 });
+  return fs.outputJson(dataPath, groupData, { spaces: 2 }); // don't need to wait for it to complete, so not a sync operation
 }
 
 /**

--- a/src/helpers/groupDataHelpers.js
+++ b/src/helpers/groupDataHelpers.js
@@ -74,7 +74,7 @@ export function getGroupDataIndexPath(toolName, projectDir, groupID) {
  */
 export function saveGroupData(toolName, projectDir, groupID, groupData) {
   const dataPath = getGroupDataIndexPath(toolName, projectDir, groupID);
-  return fs.outputJson(dataPath, groupData);
+  return fs.outputJson(dataPath, groupData, { spaces: 2 });
 }
 
 /**

--- a/src/helpers/verseEditHelpers.js
+++ b/src/helpers/verseEditHelpers.js
@@ -1,5 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path-extra';
+import { getGroupsData } from '../selectors';
+import { saveGroupData } from '../helpers/groupDataHelpers';
 
 /**
  * Save verse edit in translationWords to file system
@@ -30,3 +32,21 @@ export const writeTranslationWordsVerseEditToFile = (verseEdit, projectSaveLocat
   const filePath = path.join(verseEditsPath, newFilename.replace(/[:"]/g, '_'));
   fs.outputJSONSync(filePath, verseEdit, { spaces: 2 });
 };
+
+/**
+ * update the group data for edited verses
+ * @param {object} state
+ * @param {object} editedChecks - groups with edited verses
+ * @param {string} toolName
+ * @param {string} projectSaveLocation
+ */
+export function updateGroupDataIndexForVerseEdits(state, editedChecks, toolName, projectSaveLocation) {
+  const groupsData = getGroupsData(state);
+  const editedGroups = Object.keys(editedChecks);
+
+  for (let i = 0, l = editedGroups.length; i < l; i++) {
+    const groupID = editedGroups[i];
+    const groupData = groupsData[groupID];
+    saveGroupData(toolName, projectSaveLocation, groupID, groupData);
+  }
+}

--- a/src/state/actions/selectionsActions.js
+++ b/src/state/actions/selectionsActions.js
@@ -22,7 +22,7 @@ import { getGroupDataForVerse } from '../../helpers/groupDataHelpers';
 import { saveSelectionsForOtherContext, saveSelections } from '../../localStorage/saveMethods';
 // selectors
 import { getContextId, getGroupsData } from '../../selectors';
-import { generateLoadPath, loadCheckData } from '../../helpers/checkDataHelpers';
+import { loadCheckDataForKey } from '../../helpers/checkDataHelpers';
 import {
   CHANGE_SELECTIONS,
   TOGGLE_SELECTIONS_IN_GROUPDATA,
@@ -180,8 +180,7 @@ export const validateSelections = (targetVerse, contextId = null, chapterNumber 
  */
 export const getSelectionsForContextID = (projectSaveLocation, contextId) => {
   let selections = [];
-  const loadPath = generateLoadPath(projectSaveLocation, contextId, 'selections');
-  const selectionsObject = loadCheckData(loadPath, contextId);
+  const selectionsObject = loadCheckDataForKey(projectSaveLocation, contextId, 'selections');
 
   if (selectionsObject) {
     selections = selectionsObject.selections;

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -5,7 +5,7 @@ import {
   TRANSLATION_WORDS,
   TRANSLATION_NOTES,
 } from '../../common/constants';
-import { getGroupDataForVerse } from '../../helpers/groupDataHelpers';
+import { getGroupDataForVerse, saveGroupData } from '../../helpers/groupDataHelpers';
 import { saveVerseEdit } from '../../localStorage/saveMethods';
 import delay from '../../utils/delay';
 import {
@@ -177,6 +177,14 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
 
     if (groupEditsCount) {
       console.info(`doBackgroundVerseEditsUpdates() - ${groupEditsCount} group edits found`);
+
+      // update group data index files
+      for (let i = 0; i < groupEditsCount; i++) {
+        const grpEdit = groupEditsCount[i];
+        const groupID = grpEdit.groupID;
+        const groupData = groupsData[groupID];
+        saveGroupData(toolName, projectSaveLocation, groupID, groupData);
+      }
     }
   }
 

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -5,7 +5,8 @@ import {
   TRANSLATION_WORDS,
   TRANSLATION_NOTES,
 } from '../../common/constants';
-import { getGroupDataForVerse, saveGroupData } from '../../helpers/groupDataHelpers';
+import { getGroupDataForVerse } from '../../helpers/groupDataHelpers';
+import { updateGroupDataIndexForVerseEdits } from '../../helpers/verseEditHelpers';
 import { saveVerseEdit } from '../../localStorage/saveMethods';
 import delay from '../../utils/delay';
 import {
@@ -135,24 +136,6 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
   dispatch(doBackgroundVerseEditsUpdates(verseEdit, contextIdWithVerseEdit,
     currentCheckContextId, actionsBatch, currentToolName, projectSaveLocation));
 };
-
-/**
- * update the group data for edited verses
- * @param {object} state
- * @param {object} editedChecks - groups with edited verses
- * @param {string} toolName
- * @param {string} projectSaveLocation
- */
-function updateGroupDataIndexForVerseEdits(state, editedChecks, toolName, projectSaveLocation) {
-  const groupsData = getGroupsData(state);
-  const editedGroups = Object.keys(editedChecks);
-
-  for (let i = 0, l = editedGroups.length; i < l; i++) {
-    const groupID = editedGroups[i];
-    const groupData = groupsData[groupID];
-    saveGroupData(toolName, projectSaveLocation, groupID, groupData);
-  }
-}
 
 /**
  * after a delay it starts updating the verse edit flags.  There are also delays between operations

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -137,6 +137,24 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
 };
 
 /**
+ * update the group data for edited verses
+ * @param {object} state
+ * @param {object} editedChecks - groups with edited verses
+ * @param {string} toolName
+ * @param {string} projectSaveLocation
+ */
+function updateGroupDataIndexForVerseEdits(state, editedChecks, toolName, projectSaveLocation) {
+  const groupsData = getGroupsData(state);
+  const editedGroups = Object.keys(editedChecks);
+
+  for (let i = 0, l = editedGroups.length; i < l; i++) {
+    const groupID = editedGroups[i];
+    const groupData = groupsData[groupID];
+    saveGroupData(toolName, projectSaveLocation, groupID, groupData);
+  }
+}
+
+/**
  * after a delay it starts updating the verse edit flags.  There are also delays between operations
  *   so we don't slow down UI interactions of user
  * @param {{
@@ -184,14 +202,7 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
     dispatch(batchActions(actionsBatch));
 
     // update group data index files with new data
-    const groupsData = getGroupsData(getState());
-    const editedGroups = Object.keys(editedChecks);
-
-    for (let i = 0, l = editedGroups.length; i < l; i++) {
-      const groupID = editedGroups[i];
-      const groupData = groupsData[groupID];
-      saveGroupData(toolName, projectSaveLocation, groupID, groupData);
-    }
+    updateGroupDataIndexForVerseEdits(getState(), editedChecks, toolName, projectSaveLocation);
   }
 };
 

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -169,27 +169,29 @@ export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit,
   const actionsBatch = Array.isArray(batchGroupData) ? batchGroupData : []; // if batch array passed in then use it, otherwise create new array
   const state = getState();
   const groupsData = getGroupsData(state);
+  const editedChecks = {};
 
   if (toolName === TRANSLATION_WORDS || toolName === TRANSLATION_NOTES) {
-    const editedChecks = {};
     getCheckVerseEditsInGroupData(groupsData, contextIdWithVerseEdit, editedChecks, projectSaveLocation);
     const { groupEditsCount } = editChecksToBatch(editedChecks, actionsBatch); // optimize edits into batch
 
     if (groupEditsCount) {
       console.info(`doBackgroundVerseEditsUpdates() - ${groupEditsCount} group edits found`);
-
-      // update group data index files
-      for (let i = 0; i < groupEditsCount; i++) {
-        const grpEdit = groupEditsCount[i];
-        const groupID = grpEdit.groupID;
-        const groupData = groupsData[groupID];
-        saveGroupData(toolName, projectSaveLocation, groupID, groupData);
-      }
     }
   }
 
   if (actionsBatch.length) {
     dispatch(batchActions(actionsBatch));
+
+    // update group data index files with new data
+    const groupsData = getGroupsData(getState());
+    const editedGroups = Object.keys(editedChecks);
+
+    for (let i = 0, l = editedGroups.length; i < l; i++) {
+      const groupID = editedGroups[i];
+      const groupData = groupsData[groupID];
+      saveGroupData(toolName, projectSaveLocation, groupID, groupData);
+    }
   }
 };
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- verse edits indicators not saved for all checks for a verse

#### Please include detailed Test instructions for your pull request:
- testing: checkout tCore branch `bugfix-mcleanb-6678`, do `npm run load-apps` `npm ci`
- open a clean titus project select en for GL of tW.  launch tW.  Select group `pure, purify..`
- do edit of Titus 1:15 and should see verse edit indications for all 3 instances in group `pure, purify..`
- restart tCore, reopen project and launch tW - should still see verse edit indications for all 3 instances of 1:15.