### PR TITLE
Bugfix 6675/fix verse edit indication in tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4249,8 +4249,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4268,13 +4267,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4287,18 +4284,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4401,8 +4395,7 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4412,7 +4405,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4425,20 +4417,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4455,7 +4444,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4536,8 +4524,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4547,7 +4534,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4623,8 +4609,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4654,7 +4639,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4672,7 +4656,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4711,13 +4694,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.3-beta.7",
+  "version": "3.0.3-beta.8",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.3-beta.6",
+  "version": "3.0.3-beta.7",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.3-beta.4",
+  "version": "3.0.3-beta.6",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.3-beta.8",
+  "version": "3.0.3",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.3-beta",
+  "version": "3.0.3-beta.2",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.3-beta.2",
+  "version": "3.0.3-beta.4",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.0.2",
+  "version": "3.0.3-beta",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/Api.js
+++ b/src/Api.js
@@ -8,7 +8,7 @@ import path from 'path-extra';
 import usfm from 'usfm-js';
 import fs from 'fs-extra';
 import isEqual from 'deep-equal';
-import { checkSelectionOccurrences } from 'selections';
+import { checkSelectionOccurrences, getGroupsData } from 'selections';
 import { updateGroupDataForVerseEdit } from './state/actions/verseEditActions';
 import { getGroupDataForVerse } from './helpers/groupDataHelpers';
 import { getSelectionsFromChapterAndVerseCombo, generateTimestamp } from './helpers/validationHelpers';
@@ -119,15 +119,13 @@ export default class Api extends ToolApi {
         targetBook,
         bookId,
         username: userName,
-        project: {
-          getGroupsData,
-          _projectPath: projectSaveLocation,
-        },
+        project: { _projectPath: projectSaveLocation },
       },
       tool: { name: toolName },
     } = this.props;
-    const _groupsData = groupsData || getGroupsData(toolName);
-    const groupsDataKeys = Object.keys(groupsData);
+    const { store } = this.context;
+    const _groupsData = groupsData || getGroupsData(store.getState());
+    const groupsDataKeys = Object.keys(_groupsData);
     const bibleChapter = targetBook[chapter];
     const targetVerse = bibleChapter[verse];
     const selectionsChanged = this._validateVerse(targetVerse, chapter, verse, _groupsData, groupsDataKeys, silent);
@@ -143,7 +141,6 @@ export default class Api extends ToolApi {
     const isVerseEdited = loadVerseEdit(projectSaveLocation, contextId);
 
     if (isVerseEdited) { // if verse has been edited, make sure checks in groupData for verse have the verse edit set
-      const { store } = this.context;
       store.dispatch(updateGroupDataForVerseEdit(projectSaveLocation, toolName, contextId));
     }
     return selectionsChanged;

--- a/src/Api.js
+++ b/src/Api.js
@@ -151,7 +151,7 @@ export default class Api extends ToolApi {
     if (isVerseEdited) { // if verse has been edited, make sure checks in groupData for verse have the verse edit set
       store.dispatch(updateGroupDataForVerseEdit(projectSaveLocation, toolName, contextId));
     }
-    return selectionsChanged;
+    return !selectionsChanged;
   }
 
   /**

--- a/src/Api.js
+++ b/src/Api.js
@@ -8,8 +8,10 @@ import path from 'path-extra';
 import usfm from 'usfm-js';
 import fs from 'fs-extra';
 import isEqual from 'deep-equal';
-import { checkSelectionOccurrences, getGroupsData } from 'selections';
+import { checkSelectionOccurrences } from 'selections';
+import { getGroupsData } from './selectors/index';
 import { updateGroupDataForVerseEdit } from './state/actions/verseEditActions';
+import { loadGroupsData } from './state/actions/groupsDataActions';
 import { getGroupDataForVerse } from './helpers/groupDataHelpers';
 import { getSelectionsFromChapterAndVerseCombo, generateTimestamp } from './helpers/validationHelpers';
 import { getQuoteAsString } from './helpers/checkAreaHelpers';
@@ -124,7 +126,13 @@ export default class Api extends ToolApi {
       tool: { name: toolName },
     } = this.props;
     const { store } = this.context;
-    const _groupsData = groupsData || getGroupsData(store.getState());
+    let _groupsData = groupsData || getGroupsData(store.getState());
+
+    if (!Object.keys(_groupsData).length) { // if groups data not loaded
+      store.dispatch(loadGroupsData(toolName, projectSaveLocation));
+      _groupsData = getGroupsData(store.getState()); // refresh with latest group data
+    }
+
     const groupsDataKeys = Object.keys(_groupsData);
     const bibleChapter = targetBook[chapter];
     const targetVerse = bibleChapter[verse];

--- a/src/Api.js
+++ b/src/Api.js
@@ -111,6 +111,7 @@ export default class Api extends ToolApi {
    * @param {String} verse
    * @param {boolean} silent - if true then don't show alerts
    * @param {Object} groupsData
+   * @return {boolean} returns true if no selections invalidate
    */
   validateVerse(chapter, verse, silent = false, groupsData) {
     const {
@@ -129,7 +130,7 @@ export default class Api extends ToolApi {
     const groupsDataKeys = Object.keys(groupsData);
     const bibleChapter = targetBook[chapter];
     const targetVerse = bibleChapter[verse];
-    this._validateVerse(targetVerse, chapter, verse, _groupsData, groupsDataKeys, silent);
+    const selectionsChanged = this._validateVerse(targetVerse, chapter, verse, _groupsData, groupsDataKeys, silent);
 
     // check for verse edit
     const contextId = {
@@ -145,6 +146,7 @@ export default class Api extends ToolApi {
       const { store } = this.context;
       store.dispatch(updateGroupDataForVerseEdit(projectSaveLocation, toolName, contextId));
     }
+    return selectionsChanged;
   }
 
   /**
@@ -155,6 +157,7 @@ export default class Api extends ToolApi {
    * @param {Object} groupsData
    * @param {Array} groupsDataKeys - quick lookup for keys in groupsData
    * @param {boolean} silent - if true then don't show alerts
+   * @return {boolean} returns true if no selections invalidate
    */
   _validateVerse(targetVerse, chapter, verse, groupsData, groupsDataKeys, silent, modifiedTimestamp) {
     let {
@@ -232,6 +235,7 @@ export default class Api extends ToolApi {
     if (selectionsChanged && !silent) {
       this._showResetDialog();
     }
+    return !selectionsChanged;
   }
 
   writeCheckData(payload = {}, checkPath, modifiedTimestamp) {

--- a/src/Api.js
+++ b/src/Api.js
@@ -113,7 +113,7 @@ export default class Api extends ToolApi {
    * @param {String} verse
    * @param {boolean} silent - if true then don't show alerts
    * @param {Object} groupsData
-   * @return {boolean} returns true if no selections invalidate
+   * @return {boolean} returns true if no selections invalidated
    */
   validateVerse(chapter, verse, silent = false, groupsData) {
     const {
@@ -136,7 +136,7 @@ export default class Api extends ToolApi {
     const groupsDataKeys = Object.keys(_groupsData);
     const bibleChapter = targetBook[chapter];
     const targetVerse = bibleChapter[verse];
-    const selectionsChanged = this._validateVerse(targetVerse, chapter, verse, _groupsData, groupsDataKeys, silent);
+    const selectionsValid = this._validateVerse(targetVerse, chapter, verse, _groupsData, groupsDataKeys, silent);
 
     // check for verse edit
     const contextId = {
@@ -151,7 +151,7 @@ export default class Api extends ToolApi {
     if (isVerseEdited) { // if verse has been edited, make sure checks in groupData for verse have the verse edit set
       store.dispatch(updateGroupDataForVerseEdit(projectSaveLocation, toolName, contextId));
     }
-    return !selectionsChanged;
+    return selectionsValid;
   }
 
   /**
@@ -162,7 +162,7 @@ export default class Api extends ToolApi {
    * @param {Object} groupsData
    * @param {Array} groupsDataKeys - quick lookup for keys in groupsData
    * @param {boolean} silent - if true then don't show alerts
-   * @return {boolean} returns true if no selections invalidate
+   * @return {boolean} returns true if no selections invalidated
    */
   _validateVerse(targetVerse, chapter, verse, groupsData, groupsDataKeys, silent, modifiedTimestamp) {
     let {

--- a/src/helpers/checkDataHelpers.js
+++ b/src/helpers/checkDataHelpers.js
@@ -229,7 +229,7 @@ export function loadSelections(projectSaveLocation, contextId) {
 }
 
 /**
- * checks to see if verseEdits are recorded in checks.
+ * checks to see if verseEdits are recorded for this verse in checks.
  * @param {*} projectSaveLocation - project path.
  * @param {*} contextId - context id.
  * @return {Boolean} true if verse has been edited

--- a/src/helpers/checkDataHelpers.js
+++ b/src/helpers/checkDataHelpers.js
@@ -125,10 +125,10 @@ export function loadComments(projectSaveLocation, contextId) {
 
 /**
  * Loads the latest invalidated file from the file system for the specify contextID.
- * @param {*} projectSaveLocation - project path.
+ * @param {string} projectSaveLocation - project path.
  * @param {*} contextId - context id.
- * @param {*} gatewayLanguageCode - gateway language code.
- * @param {*} gatewayLanguageQuote - gateway language quote.
+ * @param {string} gatewayLanguageCode - gateway language code.
+ * @param {string} gatewayLanguageQuote - gateway language quote.
  */
 export function loadInvalidated(projectSaveLocation, contextId, gatewayLanguageCode, gatewayLanguageQuote) {
   const invalidatedObject = loadCheckDataForKey(projectSaveLocation, contextId, 'invalidated');
@@ -157,10 +157,10 @@ export function loadInvalidated(projectSaveLocation, contextId, gatewayLanguageC
 
 /**
  * Loads the latest bookmarks file from the file system for the specify contextID.
- * @param {*} projectSaveLocation - project path.
+ * @param {string} projectSaveLocation - project path.
  * @param {*} contextId - context id.
- * @param {*} gatewayLanguageCode - gateway language code.
- * @param {*} gatewayLanguageQuote - gateway language quote.
+ * @param {string} gatewayLanguageCode - gateway language code.
+ * @param {string} gatewayLanguageQuote - gateway language quote.
  */
 export function loadBookmarks(projectSaveLocation, contextId, gatewayLanguageCode, gatewayLanguageQuote) {
   const remindersObject = loadCheckDataForKey(projectSaveLocation, contextId, 'reminders');
@@ -189,7 +189,7 @@ export function loadBookmarks(projectSaveLocation, contextId, gatewayLanguageCod
 
 /**
  * Loads the latest selections file from the file system for the specific contextID.
- * @param {*} projectSaveLocation - project path.
+ * @param {string} projectSaveLocation - project path.
  * @param {*} contextId - context id.
  * @return {Object} Dispatches an action that loads the selectionsReducer with data.
  */
@@ -226,4 +226,15 @@ export function loadSelections(projectSaveLocation, contextId) {
       username: null,
     };
   }
+}
+
+/**
+ * checks to see if verseEdits are recorded in checks.
+ * @param {*} projectSaveLocation - project path.
+ * @param {*} contextId - context id.
+ * @return {Boolean} true if verse has been edited
+ */
+export function loadVerseEdit(projectSaveLocation, contextId) {
+  const verseEditPath = generateLoadPath(projectSaveLocation, contextId, 'verseEdits');
+  return fs.existsSync(verseEditPath);
 }

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -1,6 +1,6 @@
 import { batchActions } from 'redux-batched-actions';
 import generateTimestamp from '../../utils/generateTimestamp';
-import { getContextId, getGroupsData} from '../../selectors';
+import { getContextId, getGroupsData } from '../../selectors';
 import {
   TRANSLATION_NOTES,
   TRANSLATION_WORDS,
@@ -189,7 +189,7 @@ export const updateGroupDataForVerseEdit = (projectSaveLocation, toolName, conte
  * @param {string} toolName - tool Name.
  * @param {string} projectSaveLocation - project Directory path.
  */
-export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit, currentCheckContextId, batchGroupData = null, toolName, projectSaveLocation) => (dispatch, getState) => {
+export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit, currentCheckContextId, batchGroupData = null, toolName, projectSaveLocation) => (dispatch) => {
   const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
   const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
 

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -122,8 +122,8 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
   const actionsBatch = Array.isArray(batchGroupData) ? batchGroupData : []; // if batch array passed in then use it, otherwise create new array
   showAlert(translate('invalidation_checking'), true);
   await delay(300);
-  const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
-  const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
+  const chapterWithVerseEdit = verseEdit.activeChapter;
+  const verseWithVerseEdit = verseEdit.activeVerse;
   updateTargetVerse(chapterWithVerseEdit, verseWithVerseEdit, verseEdit.verseAfter);
 
   const showAlignmentsInvalidated = !toolApi.validateVerseAlignments(chapterWithVerseEdit, verseWithVerseEdit, true);


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fixes ValidateVerse API to get right group data and return selections valid status
- adds ValidateVerse() to update verse edits in group data if necessary
- fix for updateVerseEditStatesAndCheckAlignments() to update edited verse - not current context

#### Please include detailed Test instructions for your pull request:
- can use test build 6240f05 which includes WA fixes: https://github.com/unfoldingWord/translationCore/actions/runs/50792057
- in tN or tW: using scripture pane, edit different verse than current verse and it should mark all checks in the edited verse as edited
- in WA edit a verse and should see verse edit indications in tW and tN.

