### PR TITLE
fixed bug in localizing links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.1.6-beta.2",
+  "version": "3.1.6",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "3.1.6-beta",
+  "version": "3.1.6-beta.2",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/components/CheckInfoCardWrapper.js
+++ b/src/components/CheckInfoCardWrapper.js
@@ -21,7 +21,7 @@ function CheckInfoCardWrapper({
   groupsIndex,
   translationHelps,
   resourcesReducer,
-  tc: { appLanguage },
+  tc: { gatewayLanguageCode },
 }) {
   function getScriptureFromReference(lang, id, book, chapter, verse) {
     const chapterParsed = parseInt(chapter);
@@ -62,7 +62,7 @@ function CheckInfoCardWrapper({
    */
   function onRenderLink({ href, title }) {
     if (href.startsWith('rc://')) {
-      return formatRCLink(resourcesReducer, appLanguage, href, title);
+      return formatRCLink(resourcesReducer, gatewayLanguageCode, href, title);
     } else {
       console.warn(`Unsupported link: ${title} ${href}`);
     }

--- a/src/helpers/checkInfoCardHelpers.js
+++ b/src/helpers/checkInfoCardHelpers.js
@@ -149,7 +149,7 @@ export function formatRCLink(resourcesReducer, appLanguage, href, title) {
 
   // update the link language
   if (lang !== appLanguage) {
-    lang = appLanguage.split('_')[0]; // remove the location e.g. _US
+    lang = appLanguage.split('_')[0]; // remove the location if it exists e.g. _US
   }
 
   // update the link title


### PR DESCRIPTION
Related to unfoldingWord/translationCore#6351

Fixes the link parsing to use the correct language for the link. Before it was using the app language, now it's using the gateway language.