### PR TITLE
Bugfix 6675/Fix active verse and current verse in tW and tN tool verse edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "main": "dist/bundle.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -123,8 +123,8 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
   const actionsBatch = Array.isArray(batchGroupData) ? batchGroupData : []; // if batch array passed in then use it, otherwise create new array
   showAlert(translate('invalidation_checking'), true);
   await delay(300);
-  const chapterWithVerseEdit = verseEdit.activeChapter;
-  const verseWithVerseEdit = verseEdit.activeVerse;
+  const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
+  const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
   updateTargetVerse(chapterWithVerseEdit, verseWithVerseEdit, verseEdit.verseAfter);
 
   const showAlignmentsInvalidated = !toolApi.validateVerseAlignments(chapterWithVerseEdit, verseWithVerseEdit, true);

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -40,8 +40,11 @@ import { showInvalidatedWarnings, validateSelections } from './selectionsActions
  */
 export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before, after, tags, username, gatewayLanguageCode, gatewayLanguageQuote, projectSaveLocation, currentToolName, translate, showAlert, closeAlert, showIgnorableAlert, updateTargetVerse, toolApi) => (dispatch, getState) => {
   const state = getState();
-  const currentCheckContextId = getContextId(state);
-  const { bookId } = currentCheckContextId.reference;
+  const contextId = getContextId(state);
+  const currentCheckContextId = contextId;
+  const {
+    bookId, chapter: currentCheckChapter, verse: currentCheckVerse,
+  } = currentCheckContextId.reference;
   verseWithVerseEdit = (typeof verseWithVerseEdit === 'string') ? parseInt(verseWithVerseEdit) : verseWithVerseEdit; // make sure number
 
   const contextIdWithVerseEdit = {
@@ -65,8 +68,8 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
     tags,
     username,
     activeBook: bookId,
-    activeChapter: chapterWithVerseEdit,
-    activeVerse: verseWithVerseEdit,
+    activeChapter: currentCheckChapter,
+    activeVerse: currentCheckVerse,
     modifiedTimestamp: generateTimestamp(),
     gatewayLanguageCode,
     gatewayLanguageQuote,
@@ -83,7 +86,7 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
   );
 
   // Persisting verse edit checkData in filesystem.
-  saveVerseEdit(currentCheckContextId, verseEdit, projectSaveLocation);
+  saveVerseEdit(contextIdWithVerseEdit, verseEdit, projectSaveLocation);
 };
 
 /**


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix active verse and current verse in tW and tN tool verse edits.

#### Please include detailed Test instructions for your pull request:
- test with tC branch bugfix-mcleanb-6675
- verse edits in tN and tW (either in checker or in scripturePane) should show in wA and in verseEdits folder.
