### PR TITLE
Bugfix 6847/fix to show all target words in SP and word bank and better invalidation checking in WA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "4.7.1-alpha.2",
+  "version": "4.9.1-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8690,9 +8690,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "2.1.1-alpha",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-2.1.1-alpha.tgz",
-      "integrity": "sha512-sH35xsuoEAmnnSH2esF5cT0YfwvAEFsnpd0JYHuIwZObo2HZz6e/V/xw7EiGobHsM9dYjRZx001dtmSgngs2xg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-3.0.0.tgz",
+      "integrity": "sha512-+CTGUG/BpJWh+nxZKiYl8dNrTI3ZiFJIPPR9Gb2eYahF9JdNbuyL9s/LwLksPcmEsBeKQ/aPH9cgGEfVMxyvxQ==",
       "dev": true,
       "requires": {
         "@material-ui/core": "^3.9.4",
@@ -8708,7 +8708,7 @@
         "react-draggable": "^3.3.2",
         "react-remarkable": "^1.1.3",
         "react-tooltip": "^3.11.6",
-        "usfm-js": "2.0.4-alpha"
+        "usfm-js": "2.0.1"
       },
       "dependencies": {
         "deep-equal": {
@@ -8730,6 +8730,18 @@
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
           "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==",
           "dev": true
+        },
+        "usfm-js": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.0.1.tgz",
+          "integrity": "sha512-tH1+WQI3f9lh02301FWKdbKbz3lbxADs6hFZGchgcrOTmcwV9/aiG3RbSLtfnL4Xn0/DsSHFhf/Tf54iTpoVaA==",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "lodash": "^4.17.11",
+            "rimraf": "^2.6.3",
+            "transform-runtime": "0.0.0"
+          }
         }
       }
     },
@@ -9024,9 +9036,9 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "2.0.4-alpha",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.0.4-alpha.tgz",
-      "integrity": "sha512-pA54mbGg8U20tFUvCiyANvKb7BLthgTBQSEipzCHKwOBbdEEoZyRX3yi3eDuI4QqKYeBQv0/scp/NgEqI6qFzA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.1.0.tgz",
+      "integrity": "sha512-DemzdzAwrVeuzRwnZYOKvAle/U2ZUUf04NQSVDgqZCSFyH7hVhe2/PWC7jT2DKnPMYoa0IxnG3XGbuOPXgZ/oQ==",
       "dev": true,
       "requires": {
         "lodash.clonedeep": "^4.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2182,9 +2182,9 @@
       }
     },
     "brcast": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
-      "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.2.tgz",
+      "integrity": "sha512-f5XwwFCCuvgqP2nMH/hJ74FqnGmb4X3D+NC//HphxJzzhsZvSZa+Hk/syB7j3ZHpPDLMoYU8oBgviRWfNvEfKA==",
       "dev": true
     },
     "browser-process-hrtime": {
@@ -6135,6 +6135,11 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -8684,9 +8689,8 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-2.1.0.tgz",
-      "integrity": "sha512-wvjp1DMZb0ux5jHlcQT1nLVo+DK4hWl6RaCYhnkIFaNBiUjIkImxIpn6Mgn6EesmhPjR3SHYRVT5lgTb73PvEw==",
+      "version": "github:unfoldingWord/tc-ui-toolkit#780e442ee145ee41aa9771771997b1c70e815f45",
+      "from": "github:unfoldingWord/tc-ui-toolkit#bugfix-mcleanb-6847",
       "dev": true,
       "requires": {
         "@material-ui/core": "^3.9.4",
@@ -8702,7 +8706,7 @@
         "react-draggable": "^3.3.2",
         "react-remarkable": "^1.1.3",
         "react-tooltip": "^3.11.6",
-        "usfm-js": "2.0.1"
+        "usfm-js": "github:unfoldingWord/usfm-js#bugfix-mcleanb-6847"
       },
       "dependencies": {
         "deep-equal": {
@@ -9018,14 +9022,10 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.0.1.tgz",
-      "integrity": "sha512-tH1+WQI3f9lh02301FWKdbKbz3lbxADs6hFZGchgcrOTmcwV9/aiG3RbSLtfnL4Xn0/DsSHFhf/Tf54iTpoVaA==",
+      "version": "github:unfoldingWord/usfm-js#d2f670accb0a2e698ed3552b8fcc87a14d8b3a1d",
+      "from": "github:unfoldingWord/usfm-js#bugfix-mcleanb-6847",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "lodash": "^4.17.11",
-        "rimraf": "^2.6.3",
-        "transform-runtime": "0.0.0"
+        "lodash.clonedeep": "^4.5.0"
       }
     },
     "util": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "4.7.0",
+  "version": "4.7.1-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6138,7 +6138,8 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
     },
     "lodash.escape": {
       "version": "4.0.1",
@@ -8689,8 +8690,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "github:unfoldingWord/tc-ui-toolkit#780e442ee145ee41aa9771771997b1c70e815f45",
-      "from": "github:unfoldingWord/tc-ui-toolkit#bugfix-mcleanb-6847",
+      "version": "2.1.1-alpha",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-2.1.1-alpha.tgz",
+      "integrity": "sha512-sH35xsuoEAmnnSH2esF5cT0YfwvAEFsnpd0JYHuIwZObo2HZz6e/V/xw7EiGobHsM9dYjRZx001dtmSgngs2xg==",
       "dev": true,
       "requires": {
         "@material-ui/core": "^3.9.4",
@@ -8706,7 +8708,7 @@
         "react-draggable": "^3.3.2",
         "react-remarkable": "^1.1.3",
         "react-tooltip": "^3.11.6",
-        "usfm-js": "github:unfoldingWord/usfm-js#bugfix-mcleanb-6847"
+        "usfm-js": "2.0.4-alpha"
       },
       "dependencies": {
         "deep-equal": {
@@ -9022,8 +9024,10 @@
       "dev": true
     },
     "usfm-js": {
-      "version": "github:unfoldingWord/usfm-js#d2f670accb0a2e698ed3552b8fcc87a14d8b3a1d",
-      "from": "github:unfoldingWord/usfm-js#bugfix-mcleanb-6847",
+      "version": "2.0.4-alpha",
+      "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.0.4-alpha.tgz",
+      "integrity": "sha512-pA54mbGg8U20tFUvCiyANvKb7BLthgTBQSEipzCHKwOBbdEEoZyRX3yi3eDuI4QqKYeBQv0/scp/NgEqI6qFzA==",
+      "dev": true,
       "requires": {
         "lodash.clonedeep": "^4.5.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "4.9.1-alpha",
+  "version": "4.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9183,9 +9183,9 @@
       "dev": true
     },
     "word-aligner": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word-aligner/-/word-aligner-0.3.0.tgz",
-      "integrity": "sha512-e5pvbiX605z5Hz/l0ejdtELepiK40Zkc5XESXSHWaMi0DztQZqaVV2KPhm67JNf0ezAO+o+7kmItkYp4EWhIpg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/word-aligner/-/word-aligner-0.4.0.tgz",
+      "integrity": "sha512-TojJFi0ObcPJWgviFEAWL4av+9M6kqx6+xT17OOsJPOyFCiSsrCJwEiMTLiaWv1jo9mK0r7/u2c4B8r2i2SPvw==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -9195,8 +9195,7 @@
         "path-extra": "^4.2.1",
         "rimraf": "^2.6.2",
         "string-punctuation-tokenizer": "2.0.0",
-        "transform-runtime": "0.0.0",
-        "usfm-js": "2.0.2"
+        "transform-runtime": "0.0.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -9208,18 +9207,6 @@
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
-          }
-        },
-        "usfm-js": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.0.2.tgz",
-          "integrity": "sha512-9dykXM14qzp8+hp73xr+qz1lljtDPApUukzD/Md/pB0Dp5sAicl7OJLXhBHbQVmOKigpRS+JexIaa9x+yBWWaw==",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "lodash": "^4.17.11",
-            "rimraf": "^2.6.3",
-            "transform-runtime": "0.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8690,9 +8690,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-3.0.0.tgz",
-      "integrity": "sha512-+CTGUG/BpJWh+nxZKiYl8dNrTI3ZiFJIPPR9Gb2eYahF9JdNbuyL9s/LwLksPcmEsBeKQ/aPH9cgGEfVMxyvxQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-3.0.1.tgz",
+      "integrity": "sha512-qAvX/smVsEN0DpUuYgf6frh/SZaHt5MpEB0ElrETkh9HwsCMWRp4Tqu+yu1hdPjphsSAXyiFbnkWHGd712RKog==",
       "dev": true,
       "requires": {
         "@material-ui/core": "^3.9.4",
@@ -8707,8 +8707,7 @@
         "react-container-dimensions": "^1.3.3",
         "react-draggable": "^3.3.2",
         "react-remarkable": "^1.1.3",
-        "react-tooltip": "^3.11.6",
-        "usfm-js": "2.0.1"
+        "react-tooltip": "^3.11.6"
       },
       "dependencies": {
         "deep-equal": {
@@ -8730,18 +8729,6 @@
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
           "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==",
           "dev": true
-        },
-        "usfm-js": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/usfm-js/-/usfm-js-2.0.1.tgz",
-          "integrity": "sha512-tH1+WQI3f9lh02301FWKdbKbz3lbxADs6hFZGchgcrOTmcwV9/aiG3RbSLtfnL4Xn0/DsSHFhf/Tf54iTpoVaA==",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "lodash": "^4.17.11",
-            "rimraf": "^2.6.3",
-            "transform-runtime": "0.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^16.8.6",
     "react-redux": "^7.1.1",
     "string-punctuation-tokenizer": "^2.0.0",
-    "tc-ui-toolkit": "^2.0.0",
+    "tc-ui-toolkit": "^3.0.1",
     "usfm-js": "^2.1.0",
     "word-aligner": "^0.4.0"
   },
@@ -77,7 +77,7 @@
     "string-punctuation-tokenizer": "2.0.0",
     "style-loader": "0.23.1",
     "tc-tool": "4.0.1",
-    "tc-ui-toolkit": "3.0.0",
+    "tc-ui-toolkit": "3.0.1",
     "usfm-js": "2.1.0",
     "word-aligner": "0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -98,6 +98,6 @@
     "semver": "6.3.0",
     "simple-git": "1.126.0",
     "tc-electron-env": "0.9.0",
-    "usfm-js": "2.0.1"
+    "usfm-js": "2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "4.9.1-alpha",
+  "version": "4.9.1",
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint ./src",
@@ -36,7 +36,7 @@
     "string-punctuation-tokenizer": "^2.0.0",
     "tc-ui-toolkit": "^2.0.0",
     "usfm-js": "^2.1.0",
-    "word-aligner": "^0.3.0"
+    "word-aligner": "^0.4.0"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",
@@ -79,7 +79,7 @@
     "tc-tool": "4.0.1",
     "tc-ui-toolkit": "3.0.0",
     "usfm-js": "2.1.0",
-    "word-aligner": "0.3.0"
+    "word-aligner": "0.4.0"
   },
   "dependencies": {
     "@material-ui/icons": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "4.7.0",
+  "version": "4.7.1-alpha.2",
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint ./src",
@@ -34,8 +34,9 @@
     "react-dom": "^16.8.6",
     "react-redux": "^7.1.1",
     "string-punctuation-tokenizer": "^2.0.0",
-    "word-aligner": "^0.3.0",
-    "tc-ui-toolkit": "^1.1.3"
+    "tc-ui-toolkit": "^2.0.0",
+    "usfm-js": "^2.0.4-alpha",
+    "word-aligner": "^0.3.0"
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",
@@ -76,7 +77,8 @@
     "string-punctuation-tokenizer": "2.0.0",
     "style-loader": "0.23.1",
     "tc-tool": "4.0.1",
-    "tc-ui-toolkit": "github:unfoldingWord/tc-ui-toolkit#bugfix-mcleanb-6847",
+    "tc-ui-toolkit": "2.1.1-alpha",
+    "usfm-js": "2.0.4-alpha",
     "word-aligner": "0.3.0"
   },
   "dependencies": {
@@ -97,7 +99,6 @@
     "selections": "0.1.7",
     "semver": "6.3.0",
     "simple-git": "1.126.0",
-    "tc-electron-env": "0.9.0",
-    "usfm-js": "github:unfoldingWord/usfm-js#bugfix-mcleanb-6847"
+    "tc-electron-env": "0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "string-punctuation-tokenizer": "2.0.0",
     "style-loader": "0.23.1",
     "tc-tool": "4.0.1",
-    "tc-ui-toolkit": "2.1.0",
+    "tc-ui-toolkit": "github:unfoldingWord/tc-ui-toolkit#bugfix-mcleanb-6847",
     "word-aligner": "0.3.0"
   },
   "dependencies": {
@@ -98,6 +98,6 @@
     "semver": "6.3.0",
     "simple-git": "1.126.0",
     "tc-electron-env": "0.9.0",
-    "usfm-js": "2.0.2"
+    "usfm-js": "github:unfoldingWord/usfm-js#bugfix-mcleanb-6847"
   }
 }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- updated usfm-js and made it a peer dependency

#### Please include detailed Test instructions for your pull request:
- checkout tC branch `bugfix-mcleanb-6847`, run `npm run load-apps && npm ci && npm start`
- use github build attached to https://github.com/unfoldingWord/translationCore/pull/6966
- open project at https://drive.google.com/open?id=1nkSWNnvqHw_QVDaU5dIzNf9GZetrEB4Y
- when you open project, should see 38 new invalidations for WA
- open WA and navigate to luke 4:19
- the old builds would not show invalidations until project was exported, and would only show `4:19 और का प्रचार करूँ।”` in SP and only 4 words in the word bank
- but in this build 4:19 should show invalidated icon.  Also you should see many more words in word bank and SP as:  
![Screen Shot 2020-06-04 at 10 07 47 AM copy](https://user-images.githubusercontent.com/14238574/83773109-20709680-a652-11ea-83d6-12f64bdd2b36.png)
