### PR TITLE
Bugfix 7013/Fix Error being thrown when user prompted for invalid check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/components/VerseCheckWrapper.js
+++ b/src/components/VerseCheckWrapper.js
@@ -446,7 +446,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     },
     onInvalidCheck: () => {
       onInvalidCheck(contextId, gatewayLanguageCode, true, () => {
-        dispatch(changeToNextContextId(projectSaveLocation, userData, gatewayLanguageCode, gatewayLanguageQuote))
+        dispatch(changeToNextContextId(projectSaveLocation, userData, gatewayLanguageCode, gatewayLanguageQuote));
       });
     },
   };

--- a/src/components/VerseCheckWrapper.js
+++ b/src/components/VerseCheckWrapper.js
@@ -435,7 +435,9 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       validateSelections(targetVerse, contextId, null, null, true, {}, null, projectSaveLocation, bookId, currentToolName, username, gatewayLanguageCode, gatewayLanguageQuote);
     },
     onInvalidCheck: () => {
-      onInvalidCheck(contextId, gatewayLanguageCode, true, dispatch(changeToNextContextId(projectSaveLocation, userData, gatewayLanguageCode, gatewayLanguageQuote)));
+      onInvalidCheck(contextId, gatewayLanguageCode, true, () => {
+        dispatch(changeToNextContextId(projectSaveLocation, userData, gatewayLanguageCode, gatewayLanguageQuote))
+      });
     },
   };
 };


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- in onInvalidCheck(), fixed call to changeToNextContextId() so that it does not happen before prompt.

#### Please include detailed Test instructions for your pull request:
- use tC branch `bugfix-mcleanb-7013`, open esther project, then launch tN tool
- under category metonymy, click on Est 1:7.  Should see feedback prompt.  Click on ignore button and selection should move to next check.  Should not see the error listed in console:
![image.png](https://images.zenhubusercontent.com/5cf53901e39e5f33e3e129fa/2da61cb0-fd31-459b-9e0d-001e9fff31fb)
