### PR TITLE
strip out unsupported links from the note text

### DIFF
--- a/src/components/CheckInfoCardWrapper.js
+++ b/src/components/CheckInfoCardWrapper.js
@@ -64,11 +64,11 @@ function CheckInfoCardWrapper({
   function onRenderLink({ href, title }) {
     if (href.startsWith('rc://')) {
       return formatRCLink(resourcesReducer, gatewayLanguageCode, href, title);
-    } else {
-      console.warn(`Unsupported link: ${title} ${href}`);
     }
+    // unsupported links will be removed.
+    console.warn(`Unsupported link will be removed: ${title} ${href}`);
     return {
-      href,
+      href: null,
       title,
     };
   }

--- a/src/helpers/checkInfoCardHelpers.js
+++ b/src/helpers/checkInfoCardHelpers.js
@@ -34,8 +34,12 @@ const buildRenderer = (linkRenderer = null) => {
       text = data.title;
     }
 
-    const link = href + (title ? ' ' + title : '');
-    return '[' + text + '](' + link + ')';
+    if (href) {
+      const link = href + (title ? ' ' + title : '');
+      return '[' + text + '](' + link + ')';
+    } else {
+      return text;
+    }
   };
   return Renderer;
 };


### PR DESCRIPTION
This is related to https://github.com/unfoldingWord/translationCore/issues/6872

Links that are not supported are displayed as regular text.

before:
![image](https://user-images.githubusercontent.com/166412/86267637-3477cb80-bbf1-11ea-9467-5fb0c37f22d0.png)

after:
![image](https://user-images.githubusercontent.com/166412/86267678-478a9b80-bbf1-11ea-8e6e-fca6760ce616.png)
