### PR TITLE
Bugfix 6988/Remove book names from group menu items

### DIFF
--- a/__tests__/__snapshots__/Container.test.js.snap
+++ b/__tests__/__snapshots__/Container.test.js.snap
@@ -457,9 +457,7 @@ exports[`Container Tests Test Container 1`] = `
             <span
               class=""
             >
-              function () {
-          return 'gen';
-        } 2:5
+              2:5
             </span>
           </span>
         </div>
@@ -476,9 +474,7 @@ exports[`Container Tests Test Container 1`] = `
             <span
               class=""
             >
-              function () {
-          return 'gen';
-        } 3:2
+              3:2
             </span>
           </span>
         </div>
@@ -6080,9 +6076,7 @@ exports[`Container Tests Test empty Container 1`] = `
             <span
               class=""
             >
-              function () {
-          return 'gen';
-        } 2:5
+              2:5
             </span>
           </span>
         </div>
@@ -6099,9 +6093,7 @@ exports[`Container Tests Test empty Container 1`] = `
             <span
               class=""
             >
-              function () {
-          return 'gen';
-        } 3:2
+              3:2
             </span>
           </span>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "5.1.0-alpha",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "5.0.1",
+  "version": "5.1.0-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "5.0.1",
+  "version": "5.1.0-alpha",
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "5.1.0-alpha",
+  "version": "5.1.0",
   "main": "lib/index.js",
   "scripts": {
     "lint": "eslint ./src",

--- a/src/components/GroupMenuComponent.js
+++ b/src/components/GroupMenuComponent.js
@@ -61,7 +61,7 @@ function GroupMenuComponent({
     let title = refStr;
 
     if (selectionText) {
-      title = `${refStr} ${selectionText}`;
+      title = `${refStr} ${selectionText}\u00A0\u00A0`;
     }
 
     return {

--- a/src/components/GroupMenuComponent.js
+++ b/src/components/GroupMenuComponent.js
@@ -12,7 +12,6 @@ import {
   generateMenuItem,
   InvalidatedIcon,
   CheckIcon,
-  getTitleStr,
   getReferenceStr,
 } from 'tc-ui-toolkit';
 import { generateItemId } from '../helpers/groupMenuHelpers';
@@ -20,7 +19,6 @@ import { generateItemId } from '../helpers/groupMenuHelpers';
 function GroupMenuComponent({
   translate,
   contextId,
-  bookName,
   groupsData,
   groupsIndex,
   targetLanguageFont,
@@ -60,11 +58,10 @@ function GroupMenuComponent({
 
     // build passage title
     const refStr = getReferenceStr(chapter, verse);
-    const passageText = getTitleStr(bookName, refStr);
-    let title = passageText;
+    let title = refStr;
 
     if (selectionText) {
-      title = `${bookName} ${refStr} ${selectionText}`;
+      title = `${refStr} ${selectionText}`;
     }
 
     return {

--- a/src/components/GroupMenuComponent.js
+++ b/src/components/GroupMenuComponent.js
@@ -70,7 +70,7 @@ function GroupMenuComponent({
       itemId: generateItemId(occurrence, bookId, chapter, verse, quote),
       finished: (!!item.selections && !item.invalidated) || item.nothingToSelect,
       nothingToSelect: !!item.nothingToSelect,
-      tooltip: selectionText,
+      tooltip: title,
     };
   }
 

--- a/src/components/GroupMenuComponent.js
+++ b/src/components/GroupMenuComponent.js
@@ -61,7 +61,7 @@ function GroupMenuComponent({
     let title = refStr;
 
     if (selectionText) {
-      title = `${refStr} ${selectionText}\u00A0\u00A0`;
+      title = `${refStr} ${selectionText}`;
     }
 
     return {


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- remove book name from group menu and add reference to tooltips

#### Please include detailed Test instructions for your pull request:
- in tn and tw group menu overflows should show like this in rtl languages.  And group menu entries should not have book name:

<img width="610" alt="Screen Shot 2020-07-05 at 3 30 10 PM" src="https://user-images.githubusercontent.com/14238574/86540588-9297fd80-bed4-11ea-8748-dadfa9bdf3be.png">

- and for ltr languages:

<img width="551" alt="Screen Shot 2020-07-05 at 3 36 50 PM" src="https://user-images.githubusercontent.com/14238574/86540720-70eb4600-bed5-11ea-9da9-940ee25d2cb9.png">


- in WA group menu should show like this without book name in rtl languages:

<img width="786" alt="Screen Shot 2020-07-05 at 3 33 40 PM" src="https://user-images.githubusercontent.com/14238574/86540662-f6222b00-bed4-11ea-98d6-0d448f0cf00e.png">

- and for ltr languages:

<img width="580" alt="Screen Shot 2020-07-05 at 3 38 39 PM" src="https://user-images.githubusercontent.com/14238574/86540841-aee86a00-bed5-11ea-9631-07957d10d2e3.png">

